### PR TITLE
(fix): use `rem` instead of `em` in SvgIcon

### DIFF
--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -35,8 +35,8 @@ const SvgIconRoot = styled('svg', {
   },
 })(({ theme, styleProps }) => ({
   userSelect: 'none',
-  width: '1em',
-  height: '1em',
+  width: '1rem',
+  height: '1rem',
   display: 'inline-block',
   fill: 'currentColor',
   flexShrink: 0,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
